### PR TITLE
Handle `Tuple` type in `AZ400` check

### DIFF
--- a/flake8_alphabetize/core.py
+++ b/flake8_alphabetize/core.py
@@ -1,4 +1,4 @@
-from ast import Assign, Constant, Import, ImportFrom, List, Module, Name, Str
+from ast import Assign, Constant, Import, ImportFrom, List, Module, Name, Str, Tuple
 from enum import IntEnum
 from functools import total_ordering
 
@@ -155,7 +155,7 @@ def _find_nodes(tree):
                     if isinstance(t, Name) and t.id == "__all__":
                         value = n.value
 
-                        if isinstance(value, List):
+                        if isinstance(value, (List, Tuple)):
                             list_node = value
 
     return import_nodes, list_node

--- a/test/test_alphabetize.py
+++ b/test/test_alphabetize.py
@@ -182,6 +182,14 @@ def test_AzImport_str(pystr):
             None,
         ],
         [
+            "['ScramClient', 'ScramServer']",
+            None,
+        ],
+        [
+            "('ScramClient', 'ScramServer')",
+            None,
+        ],
+        [
             "['ScramServer', 'ScramClient']",
             (
                 1,

--- a/test/test_alphabetize.py
+++ b/test/test_alphabetize.py
@@ -163,32 +163,26 @@ def test_AzImport_str(pystr):
 
 
 @pytest.mark.parametrize(
+    "pystr",
+    [
+        "[]",
+        "()",
+        "[ScramServer]",
+        "('ScramClient',)",
+        "['ScramClient', 'ScramServer']",
+        "('ScramClient', 'ScramServer')",
+    ],
+)
+def test_find_dunder_all_ok(pystr):
+    node = parse(pystr)
+    sequence_node = node.body[-1].value
+
+    assert _find_dunder_all_error(sequence_node) is None
+
+
+@pytest.mark.parametrize(
     "pystr,error",
     [
-        [
-            "[]",
-            None,
-        ],
-        [
-            "()",
-            None,
-        ],
-        [
-            "[ScramServer]",
-            None,
-        ],
-        [
-            "('ScramClient',)",
-            None,
-        ],
-        [
-            "['ScramClient', 'ScramServer']",
-            None,
-        ],
-        [
-            "('ScramClient', 'ScramServer')",
-            None,
-        ],
         [
             "['ScramServer', 'ScramClient']",
             (
@@ -214,8 +208,8 @@ def test_AzImport_str(pystr):
 def test_find_dunder_all_error(pystr, error):
     node = parse(pystr)
     sequence_node = node.body[-1].value
-    actual_error = _find_dunder_all_error(sequence_node)
-    assert actual_error == error
+
+    assert _find_dunder_all_error(sequence_node) == error
 
 
 @pytest.mark.parametrize(

--- a/test/test_alphabetize.py
+++ b/test/test_alphabetize.py
@@ -1,4 +1,4 @@
-from ast import List, parse
+from ast import List, Tuple, parse
 
 from flake8_alphabetize import Alphabetize
 from flake8_alphabetize.core import (
@@ -12,7 +12,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "pystr,import_node_types,has_list_node",
+    "pystr,import_node_types,expected_type",
     [
         [
             """
@@ -20,24 +20,29 @@ if True:
     import scramp
 """,
             [],
-            False,
+            None,
         ],
         [
             "__all__ = []",
             [],
-            True,
+            List,
+        ],
+        [
+            "__all__ = ()",
+            [],
+            Tuple,
         ],
     ],
 )
-def test_find_nodes(pystr, import_node_types, has_list_node):
+def test_find_nodes(pystr, import_node_types, expected_type):
     import_nodes, list_node = _find_nodes(parse(pystr))
 
     assert [type(n) for n in import_nodes] == import_node_types
 
-    if has_list_node:
-        assert type(list_node) == List
-    else:
+    if expected_type is None:
         assert list_node is None
+    else:
+        assert type(list_node) == expected_type
 
 
 @pytest.mark.parametrize(
@@ -178,6 +183,16 @@ def test_AzImport_str(pystr):
         ],
         [
             "['ScramServer', 'ScramClient']",
+            (
+                1,
+                0,
+                "AZ400 The names in the __all__ are in the wrong order. The order "
+                "should be ScramClient, ScramServer",
+                Alphabetize,
+            ),
+        ],
+        [
+            "('ScramServer', 'ScramClient')",
             (
                 1,
                 0,


### PR DESCRIPTION
A small change to handle `Tuple` type alongside `List` in `_find_nodes` method.
While there were already tests for reordering tuples, the actual method that retrieves `__all__` nodes didn't take `Tuple` type into account, only `List`.