### PR TITLE
Add option to ignore case while sorting

### DIFF
--- a/flake8_alphabetize/core.py
+++ b/flake8_alphabetize/core.py
@@ -17,7 +17,7 @@ class Alphabetize:
         self.tree = tree
 
     def __iter__(self):
-        errors = _find_errors(Alphabetize.app_names, self.tree, Alphabetize.ignore_case)
+        errors = _find_errors(Alphabetize.app_names, Alphabetize.ignore_case, self.tree)
         return iter(errors)
 
     @staticmethod
@@ -73,7 +73,7 @@ def _is_in_stdlib(name):
 
 @total_ordering
 class AzImport:
-    def __init__(self, app_names, ast_node, ignore_case=False):
+    def __init__(self, app_names, ignore_case, ast_node):
         self.node = ast_node
         self.error = None
         level = None
@@ -181,7 +181,7 @@ def _find_nodes(tree):
     return import_nodes, list_node
 
 
-def _find_dunder_all_error(node, ignore_case=False):
+def _find_dunder_all_error(ignore_case, node):
     if node is not None:
         actual_list = []
         for el in node.elts:
@@ -206,11 +206,11 @@ def _find_dunder_all_error(node, ignore_case=False):
             )
 
 
-def _find_errors(app_names, tree, ignore_case=False):
+def _find_errors(app_names, ignore_case, tree):
     import_nodes, list_node = _find_nodes(tree)
     errors = []
 
-    dunder_all_error = _find_dunder_all_error(list_node, ignore_case)
+    dunder_all_error = _find_dunder_all_error(ignore_case, list_node)
     if dunder_all_error is not None:
         errors.append(dunder_all_error)
 
@@ -219,7 +219,7 @@ def _find_errors(app_names, tree, ignore_case=False):
         if isinstance(imp, Import) and len(imp.names) > 1:
             return errors
         else:
-            imports.append(AzImport(app_names, imp, ignore_case))
+            imports.append(AzImport(app_names, ignore_case, imp))
 
     len_imports = len(imports)
     if len_imports == 0:

--- a/flake8_alphabetize/core.py
+++ b/flake8_alphabetize/core.py
@@ -34,9 +34,7 @@ class Alphabetize:
         )
         option_manager.add_option(
             "--alphabetize-ignore-case",
-            type=bool,
-            metavar="ALPHABETIZE_IGNORE_CASE",
-            default=False,
+            action="store_true",
             parse_from_config=True,
             help="Ignore case while sorting imports.",
         )

--- a/flake8_alphabetize/core.py
+++ b/flake8_alphabetize/core.py
@@ -33,9 +33,9 @@ class Alphabetize:
             "Eg. 'myapp'.",
         )
         option_manager.add_option(
-            "--ignore-case",
+            "--alphabetize-ignore-case",
             type=bool,
-            metavar="IGNORE_CASE",
+            metavar="ALPHABETIZE_IGNORE_CASE",
             default=False,
             parse_from_config=True,
             help="Ignore case while sorting imports.",
@@ -45,7 +45,7 @@ class Alphabetize:
     def parse_options(cls, options):
         names = options.application_names
         cls.app_names = [] if (names is None or names == "") else names.split(",")
-        cls.ignore_case = options.ignore_case
+        cls.ignore_case = options.alphabetize_ignore_case
 
 
 def _make_error(node, code, message):

--- a/test/test_alphabetize.py
+++ b/test/test_alphabetize.py
@@ -328,3 +328,44 @@ def test_find_errors(app_names, pystr, errors, ignore_case):
     actual_errors = _find_errors(app_names, ignore_case, tree)
 
     assert actual_errors == errors
+
+
+@pytest.mark.parametrize(
+    "app_names,pystr,errors,ignore_case",
+    [
+        [
+            [],
+            "from datetime import date, MINYEAR, timedelta",
+            [
+                (
+                    1,
+                    0,
+                    "AZ200 Imported names are in the wrong order. Should be MINYEAR, "
+                    "date, timedelta",
+                    Alphabetize,
+                )
+            ],
+            False,
+        ],
+        [
+            [],
+            "from datetime import MINYEAR, date, timedelta",
+            [
+                (
+                    1,
+                    0,
+                    "AZ200 Imported names are in the wrong order. Should be date, "
+                    "MINYEAR, timedelta",
+                    Alphabetize,
+                )
+            ],
+            True,
+        ],
+    ],
+)
+def test_find_errors_case_sensitive(app_names, pystr, errors, ignore_case):
+    tree = parse(pystr)
+
+    actual_errors = _find_errors(app_names, ignore_case, tree)
+
+    assert actual_errors == errors

--- a/test/test_alphabetize.py
+++ b/test/test_alphabetize.py
@@ -64,9 +64,10 @@ def test_find_nodes(pystr, import_node_types, expected_type):
         ],
     ],
 )
-def test_AzImport_init(pystr, error):
+@pytest.mark.parametrize("ignore_case", [True, False])
+def test_AzImport_init(pystr, error, ignore_case):
     node = parse(pystr)
-    az = AzImport([], node.body[0])
+    az = AzImport([], ignore_case, node.body[0])
 
     assert az.error == error
 
@@ -137,12 +138,13 @@ def test_AzImport_init(pystr, error):
         ],
     ],
 )
-def test_AzImport_lt(app_names, pystr_a, pystr_b, is_lt):
+@pytest.mark.parametrize("ignore_case", [True, False])
+def test_AzImport_lt(app_names, pystr_a, pystr_b, is_lt, ignore_case):
     node_a = parse(pystr_a)
-    az_a = AzImport(app_names, node_a.body[0])
+    az_a = AzImport(app_names, ignore_case, node_a.body[0])
 
     node_b = parse(pystr_b)
-    az_b = AzImport(app_names, node_b.body[0])
+    az_b = AzImport(app_names, ignore_case, node_b.body[0])
 
     assert (az_a < az_b) == is_lt
 
@@ -154,10 +156,11 @@ def test_AzImport_lt(app_names, pystr_a, pystr_b, is_lt):
         "from . import version",
     ],
 )
-def test_AzImport_str(pystr):
+@pytest.mark.parametrize("ignore_case", [True, False])
+def test_AzImport_str(pystr, ignore_case):
     node = parse(pystr)
 
-    az = AzImport([], node.body[0])
+    az = AzImport([], ignore_case, node.body[0])
 
     assert str(az) == pystr
 
@@ -173,11 +176,12 @@ def test_AzImport_str(pystr):
         "('ScramClient', 'ScramServer')",
     ],
 )
-def test_find_dunder_all_ok(pystr):
+@pytest.mark.parametrize("ignore_case", [True, False])
+def test_find_dunder_all_ok(pystr, ignore_case):
     node = parse(pystr)
     sequence_node = node.body[-1].value
 
-    assert _find_dunder_all_error(sequence_node) is None
+    assert _find_dunder_all_error(ignore_case, sequence_node) is None
 
 
 @pytest.mark.parametrize(
@@ -195,7 +199,8 @@ def test_find_dunder_all_ok(pystr):
         ],
     ],
 )
-def test_find_dunder_all_error(pystr, error, py_version):
+@pytest.mark.parametrize("ignore_case", [True, False])
+def test_find_dunder_all_error(pystr, error, py_version, ignore_case):
     node = parse(pystr)
     sequence_node = node.body[-1].value
     if isinstance(sequence_node, Tuple):
@@ -204,7 +209,7 @@ def test_find_dunder_all_error(pystr, error, py_version):
         col_offset = 0
     expected = (1, col_offset, error, Alphabetize)
 
-    assert _find_dunder_all_error(sequence_node) == expected
+    assert _find_dunder_all_error(ignore_case, sequence_node) == expected
 
 
 @pytest.mark.parametrize(
@@ -316,9 +321,10 @@ import datetime, scramp""",
         ],
     ],
 )
-def test_find_errors(app_names, pystr, errors):
+@pytest.mark.parametrize("ignore_case", [True, False])
+def test_find_errors(app_names, pystr, errors, ignore_case):
     tree = parse(pystr)
 
-    actual_errors = _find_errors(app_names, tree)
+    actual_errors = _find_errors(app_names, ignore_case, tree)
 
     assert actual_errors == errors


### PR DESCRIPTION
I have a library in which I have several imports of the following form
```
from mylib import AClass, a_function, BClass, b_function
```
and I find it odd that, as results from the current `main` branch, I should change such line to
```
from mylib import AClass, BClass, a_function, b_function
```
just because by default `sorted` returns capitalized strings first, and then lower case ones.

This PR adds a new option `--alphabetize-ignore-case` to ignore case while sorting, and the corresponding tests.
With such option enabled the suggested order would be
```
from mylib import a_function, AClass, b_function, BClass
```

Do let me know if the addition of such option goes against the rationale of the statement
```
Alphabetize follows the Black formatter’s uncompromising approach and so there’s only one configuration option
```
so that I can either:
* if no support for this feature is desired: close this PR, or
* if ignoring case should be the default: create a new PR where the changes to the `sorted` calls are hardcoded (even though such change would not be backward compatible).